### PR TITLE
Migrate from Travis-CI to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: tests
+
+on:
+  push:
+    branches: [ 2.x, master ]
+  pull_request:
+    branches: [ 2.x, master ]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install dependencies
+        uses: php-actions/composer@v6
+        with:
+          version: 2
+          php_version: ${{ matrix.php-versions }}
+
+      - name: Run test suite
+        run: php tests/all_tests.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: php
-php:
-  - 5.3
-  - 5.4
-before_script: composer install --dev --prefer-source
-script: php tests/all_tests.php

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ported from [node-semver 1.1.2](https://github.com/isaacs/node-semver/tree/v1.1.2) to PHP
 
-[![Build Status](https://secure.travis-ci.org/vierbergenlars/php-semver.png?branch=master)](http://travis-ci.org/vierbergenlars/php-semver)
+[![Build Status](/actions/workflows/tests.yml/badge.svg)](/actions/workflows/tests.yml)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/vierbergenlars/php-semver/badges/quality-score.png?s=89ff49019cde97e70228ae14d2dc08b727e72157)](https://scrutinizer-ci.com/g/vierbergenlars/php-semver/)
 [![Latest Stable Version](https://poser.pugx.org/vierbergenlars/php-semver/v/stable.png)](https://packagist.org/packages/vierbergenlars/php-semver)
 [![Total Downloads](https://poser.pugx.org/vierbergenlars/php-semver/downloads.png)](https://packagist.org/packages/vierbergenlars/php-semver)


### PR DESCRIPTION
Travis-CI closed its services for open source projects in 2021.